### PR TITLE
Enable persistent identity storage in keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Plugin that uses a client certificate for authentication.
 ## Using
 Clone the plugin
 
-    $ git clone https://github.com/mwaylabs/cordova-plugin-client-certificate.git
+    $ git clone https://github.com/binderhq/cordova-plugin-client-certificate.git
 
 Create a new Cordova Project
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Plugin that uses a client certificate for authentication.
 ## Using
 Clone the plugin
 
-    $ git clone https://github.com/binderhq/cordova-plugin-client-certificate.git
+    $ git clone https://github.com/mwaylabs/cordova-plugin-client-certificate.git
 
 Create a new Cordova Project
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,6 +39,7 @@
         <config-file target="config.xml" parent="/*">
             <feature name="ClientCertificate">
                 <param name="ios-package" value="ClientCertificate"/>
+                <param name="onload" value="true" />
             </feature>
         </config-file>
 

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -174,6 +174,13 @@ OSStatus extractIdentityAndTrust(NSString *certPath, NSString *pwd, SecIdentityR
         OSStatus status = SecTrustEvaluate(*trust, &trustResult);
         if (status == errSecSuccess) {
 
+            // Clear app keychain
+            void (^deleteAllKeysForSecClass)(CFTypeRef) = ^(CFTypeRef secClass) {
+                id dict = @{(__bridge id)kSecClass: (__bridge id)secClass};
+                SecItemDelete((__bridge CFDictionaryRef) dict);
+            };
+            deleteAllKeysForSecClass(kSecClassIdentity);
+
             // Persist identity to keychain
             NSMutableDictionary *secIdentityParams = [[NSMutableDictionary alloc] init];
             [secIdentityParams setObject:(__bridge id)tempIdentity forKey:(id)kSecValueRef];

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -109,9 +109,7 @@
         }
         
         else if(authMethod == NSURLAuthenticationMethodClientCertificate ) {
-            OSStatus status = noErr;
-            SecIdentityRef myIdentity;
-            //SecTrustRef myTrust;
+            SecIdentityRef myIdentity = NULL;
             
             NSMutableDictionary *query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                           (__bridge id)kSecClass, (__bridge id)kSecClass,
@@ -128,16 +126,20 @@
                 
                 CFTypeRef result = NULL;
                 SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
-                myIdentity = (SecIdentityRef)result;
+                if(result != NULL) {
+                    myIdentity = (SecIdentityRef)result;
+                }
             }
 
             
             SecCertificateRef myCertificate;
-            SecIdentityCopyCertificate(myIdentity, &myCertificate);
-            const void *certs[] = { myCertificate };
-            CFArrayRef certsArray = CFArrayCreate(NULL, certs, 1, NULL);
-            credential = [NSURLCredential credentialWithIdentity:myIdentity certificates:(__bridge NSArray*)certsArray persistence:NSURLCredentialPersistencePermanent];
-            
+            if(myIdentity != NULL) {
+                SecIdentityCopyCertificate(myIdentity, &myCertificate);
+                const void *certs[] = { myCertificate };
+                CFArrayRef certsArray = CFArrayCreate(NULL, certs, 1, NULL);
+                credential = [NSURLCredential credentialWithIdentity:myIdentity certificates:(__bridge NSArray*)certsArray persistence:NSURLCredentialPersistencePermanent];
+            }
+
         }
         
         [protocol resolveAuthenticationChallenge:challenge withCredential:credential];

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -41,11 +41,10 @@
 
 - (void)registerAuthenticationCertificate:(CDVInvokedUrlCommand*)command
 {
-    NSString* certPath = [command argumentAtIndex:0];
+    NSString* path = [command argumentAtIndex:0];
     NSString* password = [command argumentAtIndex:1];
     
     //check certificate path
-    NSString *path = [[[NSBundle mainBundle] resourcePath] stringByAppendingFormat:@"/www/%@", certPath];
     if(![[NSFileManager defaultManager] fileExistsAtPath:path]) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[NSString stringWithFormat:@"certificate file not found: %@", path]];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -37,6 +37,11 @@
 - (void)pluginInitialize
 {
     validateSslChain = YES;
+
+    // TODO: Check for keychain item, set self as delegate if so
+    
+    [CustomHTTPProtocol setDelegate:self];
+    [CustomHTTPProtocol start];
 }
 
 - (void)registerAuthenticationCertificate:(CDVInvokedUrlCommand*)command

--- a/typings/cordova-plugin-client-certifiate.d.ts
+++ b/typings/cordova-plugin-client-certifiate.d.ts
@@ -1,0 +1,6 @@
+interface CordovaClientCertificatePlugin {
+    registerAuthenticationCertificate(certificatePath: string, certificatePassword: string, successCallback: (message: string) => void, errorCallback: (error: string) => void);
+    validateSslChain(validate: any, successCallback: (success: string) => void, errorCallback: (error: string) => void);
+}
+
+declare var clientCertificate: CordovaClientCertificatePlugin;


### PR DESCRIPTION
- Allow specifying certificate location outside of www/
- Save identity to app keychain
- Set ClientCertificate as HTTP delegate on plugin load
